### PR TITLE
fix:modify return type of SQRT

### DIFF
--- a/java_programs/SQRT.java
+++ b/java_programs/SQRT.java
@@ -11,8 +11,8 @@ import java.util.*;
  * @author derricklin
  */
 public class SQRT {
-    public static float sqrt(float x, float epsilon) {
-        float approx = x / 2f;
+    public static double sqrt(double x, double epsilon) {
+        double approx = x / 2f;
         while (Math.abs(x-approx) > epsilon) {
             approx = 0.5f * (approx + x / approx);
         }


### PR DESCRIPTION
Hi all,
In this PR, I am requesting to modify the return type from "float" to "double" in the buggy SQRT program. 

The reasons are:
[[2, 0.01], 1.4166666666666665]

Above is an example of JSON test of SQRT, we compares the result (float type) with 1.4166666666666665.  However, the Float type in Java can only represent decimal values to 7 digits. So we cannot compare a Float Java value with 1.4166666666666665. 

Even if we correct the bug and cast the value "1.4166666666666665" to a Float value,  we have issue of precision lost. Then in our test, we will have issues like: expected:<1.4166666> but was:<1.4166667>.  This still makes our test fail even we fix the bug.

Thus, in Java we need the program returns a double type result for comparison.





