### PR TITLE
Add missing MINIMUM_SPANNING_TREE junit test files

### DIFF
--- a/java_testcases/junit/crt_program/MINIMUM_SPANNING_TREE_TEST.java
+++ b/java_testcases/junit/crt_program/MINIMUM_SPANNING_TREE_TEST.java
@@ -1,4 +1,4 @@
-package java_testcases.junit;
+package java_testcases.junit.crt_program;
 
 import static org.junit.Assert.assertEquals;
 
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import java_programs.MINIMUM_SPANNING_TREE;
+import correct_java_programs.MINIMUM_SPANNING_TREE;
 import java_programs.Node;
 import java_programs.WeightedEdge;
 


### PR DESCRIPTION
The `MINIMUM_SPANNING_TREE` junit test file in the [`java_testcases/junit`](https://github.com/jkoppel/QuixBugs/blob/master/java_testcases/junit/MINIMUM_SPANNING_TREE_TEST.java) directory doesn't have assert statements and is pointing to the correct version of the `MINIMUM_SPANNING_TREE.java` source file instead of the buggy one. Also, there isn't a `MINIMUM_SPANNING_TREE_TEST` file in the `crt_program` directory.

I added the test file that contains assert statements from [KTH/quixbugs-experiment](https://github.com/KTH/quixbugs-experiment) repository to both buggy and correct junit test directories with modification in its timeout to match other tests' timeout.